### PR TITLE
Re-work message clean up, re-work of the admin system and cleaning up left guilds

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -986,102 +986,89 @@ async def set_systemchannel(ctx):
     else:
         await ctx.send("You do not have an admin role.")
 
-
+@commands.is_owner()
 @bot.command(name="colour")
 async def set_colour(ctx):
-    if isadmin(ctx.message.author, ctx.guild.id):
-        msg = ctx.message.content.split()
-        args = len(msg) - 1
-        if args:
-            global botcolour
-            colour = msg[1]
-            try:
-                botcolour = discord.Colour(int(colour, 16))
+    msg = ctx.message.content.split()
+    args = len(msg) - 1
+    if args:
+        global botcolour
+        colour = msg[1]
+        try:
+            botcolour = discord.Colour(int(colour, 16))
 
-                config["server"]["colour"] = colour
-                with open(f"{directory}/config.ini", "w") as configfile:
-                    config.write(configfile)
+            config["server"]["colour"] = colour
+            with open(f"{directory}/config.ini", "w") as configfile:
+                config.write(configfile)
 
-                example = discord.Embed(
-                    title="Example embed",
-                    description="This embed has a new colour!",
-                    colour=botcolour,
-                )
-                await ctx.send("Colour changed.", embed=example)
+            example = discord.Embed(
+                title="Example embed",
+                description="This embed has a new colour!",
+                colour=botcolour,
+            )
+            await ctx.send("Colour changed.", embed=example)
 
-            except ValueError:
-                await ctx.send(
-                    "Please provide a valid hexadecimal value. Example:"
-                    f" `{prefix}colour 0xffff00`"
-                )
-
-        else:
+        except ValueError:
             await ctx.send(
-                f"Please provide a hexadecimal value. Example: `{prefix}colour"
-                " 0xffff00`"
+                "Please provide a valid hexadecimal value. Example:"
+                f" `{prefix}colour 0xffff00`"
             )
 
+    else:
+        await ctx.send(
+            f"Please provide a hexadecimal value. Example: `{prefix}colour"
+            " 0xffff00`"
+        )
 
+@commands.is_owner()
 @bot.command(name="activity")
 async def add_activity(ctx):
-    if isadmin(ctx.message.author, ctx.guild.id):
-        activity = ctx.message.content[(len(prefix) + len("activity")) :].strip()
-        if not activity:
-            await ctx.send(
-                "Please provide the activity you would like to"
-                f" add.\n```\n{prefix}activity your activity text here\n```"
-            )
+    activity = ctx.message.content[(len(prefix) + len("activity")) :].strip()
+    if not activity:
+        await ctx.send(
+            "Please provide the activity you would like to"
+            f" add.\n```\n{prefix}activity your activity text here\n```"
+        )
 
-        elif "," in activity:
-            await ctx.send("Please do not use commas `,` in your activity.")
-
-        else:
-            activities.add(activity)
-            await ctx.send(f"The activity `{activity}` was added succesfully.")
+    elif "," in activity:
+        await ctx.send("Please do not use commas `,` in your activity.")
 
     else:
-        await ctx.send("You do not have an admin role.")
+        activities.add(activity)
+        await ctx.send(f"The activity `{activity}` was added succesfully.")
 
-
+@commands.is_owner()
 @bot.command(name="activitylist")
 async def list_activities(ctx):
-    if isadmin(ctx.message.author, ctx.guild.id):
-        if activities.activity_list:
-            formatted_list = []
-            for activity in activities.activity_list:
-                formatted_list.append(f"`{activity}`")
+    if activities.activity_list:
+        formatted_list = []
+        for activity in activities.activity_list:
+            formatted_list.append(f"`{activity}`")
 
-            await ctx.send(
-                "The current activities are:\n- " + "\n- ".join(formatted_list)
-            )
-
-        else:
-            await ctx.send("There are no activities to show.")
+        await ctx.send(
+            "The current activities are:\n- " + "\n- ".join(formatted_list)
+        )
 
     else:
-        await ctx.send("You do not have an admin role.")
+        await ctx.send("There are no activities to show.")
 
-
+@commands.is_owner()
 @bot.command(name="rm-activity")
 async def remove_activity(ctx):
-    if isadmin(ctx.message.author, ctx.guild.id):
-        activity = ctx.message.content[(len(prefix) + len("rm-activity")) :].strip()
-        if not activity:
-            await ctx.send(
-                "Please paste the activity you would like to"
-                f" remove.\n```\n{prefix}rm-activity your activity text here\n```"
-            )
-            return
+    activity = ctx.message.content[(len(prefix) + len("rm-activity")) :].strip()
+    if not activity:
+        await ctx.send(
+            "Please paste the activity you would like to"
+            f" remove.\n```\n{prefix}rm-activity your activity text here\n```"
+        )
+        return
 
-        removed = activities.remove(activity)
-        if removed:
-            await ctx.send(f"The activity `{activity}` was removed.")
-
-        else:
-            await ctx.send("The activity you mentioned does not exist.")
+    removed = activities.remove(activity)
+    if removed:
+        await ctx.send(f"The activity `{activity}` was removed.")
 
     else:
-        await ctx.send("You do not have an admin role.")
+        await ctx.send("The activity you mentioned does not exist.")
 
 
 @bot.command(name="help")
@@ -1219,53 +1206,46 @@ async def print_version(ctx):
     else:
         await ctx.send("You do not have an admin role.")
 
-
+@commands.is_owner()
 @bot.command(name="kill")
 async def kill(ctx):
-    if isadmin(ctx.message.author, ctx.guild.id):
-        await ctx.send("Shutting down...")
+    await ctx.send("Shutting down...")
+    shutdown()  # sys.exit()
+
+@commands.is_owner()
+@bot.command(name="restart")
+async def restart_cmd(ctx):
+    if platform != "win32":
+        restart()
+        await ctx.send("Restarting...")
         shutdown()  # sys.exit()
 
     else:
-        await ctx.send("You do not have an admin role.")
+        await ctx.send("I cannot do this on Windows.")
 
-
-@bot.command(name="restart")
-async def restart_cmd(ctx):
-    if isadmin(ctx.message.author, ctx.guild.id):
-        if platform != "win32":
-            restart()
-            await ctx.send("Restarting...")
-            shutdown()  # sys.exit()
-
-        else:
-            await ctx.send("I cannot do this on Windows.")
-
-    else:
-        await ctx.send("You do not have an admin role.")
-
-
+@commands.is_owner()
 @bot.command(name="update")
 async def update(ctx):
-    if isadmin(ctx.message.author, ctx.guild.id):
-        if platform != "win32":
-            await ctx.send("Attempting update...")
-            os.chdir(directory)
-            cmd = os.popen("git fetch")
-            cmd.close()
-            cmd = os.popen("git pull")
-            cmd.close()
-            await ctx.send("Creating database backup...")
-            copy(db_file, f"{db_file}.bak")
-            restart()
-            await ctx.send("Restarting...")
-            shutdown()  # sys.exit()
-
-        else:
-            await ctx.send("I cannot do this on Windows.")
+    if platform != "win32":
+        await ctx.send("Attempting update...")
+        os.chdir(directory)
+        cmd = os.popen("git fetch")
+        cmd.close()
+        cmd = os.popen("git pull")
+        cmd.close()
+        await ctx.send("Creating database backup...")
+        copy(db_file, f"{db_file}.bak")
+        restart()
+        await ctx.send("Restarting...")
+        shutdown()  # sys.exit()
 
     else:
-        await ctx.send("You do not have an admin role.")
+        await ctx.send("I cannot do this on Windows.")
+
+@bot.event
+async def on_command_error(ctx, error):
+    if isinstance(error, commands.NotOwner):
+        await ctx.send("Only the bot owner may execute this command.")
 
 try:
     bot.run(TOKEN)

--- a/bot.py
+++ b/bot.py
@@ -229,7 +229,7 @@ async def cleandb():
             if channel is None:
                 channel = await bot.fetch_channel(channel_id)
 
-            await channel.fetch_message(message)
+            await channel.fetch_message(message[0])
 
         except discord.NotFound as e:
             # If unknown channel or unknown message
@@ -251,12 +251,13 @@ async def cleandb():
                 )
 
         except discord.Forbidden:
-            await system_notification(
-                channel.guild.id,
-                "I do not have access to a message I have created anymore. "
-                "I cannot manage the roles of users reacting to it."
-                f"\n\nID: {message} in {channel.mention}",
-            )
+            # If we can't fetch the channel due to the bot not being in the guild or permissions we usually cant mention it or get the guilds id using the channels object
+                await system_notification(
+                    message[3],
+                    "I do not have access to a message I have created anymore. "
+                    "I cannot manage the roles of users reacting to it."
+                    f"\n\nID: {message[0]} in channel {message[1]}",
+                )
 
     if isinstance(guilds, Exception):
         await system_notification(
@@ -344,7 +345,7 @@ async def on_ready():
         )
 
     database_updates()
-
+    db.migrate_admins(bot)
     maintain_presence.start()
     cleandb.start()
     check_cleanup_queued_guilds.start()

--- a/bot.py
+++ b/bot.py
@@ -321,6 +321,9 @@ async def on_ready():
     cleandb.start()
     updates.start()
 
+@bot.event
+async def on_guild_remove(guild):
+    db.remove_guild(guild.id)
 
 @bot.event
 async def on_message(message):

--- a/core/database.py
+++ b/core/database.py
@@ -40,7 +40,6 @@ def initialize(database):
     )
     cursor.execute("CREATE TABLE IF NOT EXISTS 'admins' ('role_id' INT, 'guild_id' INT);")
     cursor.execute("CREATE TABLE IF NOT EXISTS 'cleanup_queue_guilds' ('guild_id' INT, 'unix_timestamp' INT);")
-    cursor.execute("CREATE TABLE IF NOT EXISTS 'cleanup_queue_reactionmessage' ('reactionrole_id' INT, 'guild_id' INT, 'unix_timestamp' INT);")
     cursor.execute("CREATE TABLE IF NOT EXISTS 'dbinfo' ('version' INT);")
     cursor.execute(
         "CREATE TABLE IF NOT EXISTS 'systemchannels' ('guild_id' INT, 'channel_id'"
@@ -50,10 +49,7 @@ def initialize(database):
         "CREATE UNIQUE INDEX IF NOT EXISTS guild_id_idx ON systemchannels (guild_id);"
     )
     cursor.execute(
-        "CREATE UNIQUE INDEX IF NOT EXISTS guild_id_idx ON cleanup_queue_guilds (guild_id);"
-    )
-    cursor.execute(
-        "CREATE UNIQUE INDEX IF NOT EXISTS reactionrole_id_idx ON cleanup_queue_reactionmessage (reactionrole_id);"
+        "CREATE UNIQUE INDEX IF NOT EXISTS guild_id_index ON cleanup_queue_guilds (guild_id);"
     )
     conn.commit()
     cursor.close()

--- a/core/database.py
+++ b/core/database.py
@@ -264,6 +264,40 @@ class Database:
         except sqlite3.Error as e:
             return e
 
+    def remove_guild(self, guild_id):
+        try:
+            conn = sqlite3.connect(self.database)
+            cursor = conn.cursor()
+            # Deleting the guilds reaction-role database entries
+            cursor.execute(
+                "SELECT reactionrole_id FROM messages WHERE guild_id = ?;",
+                (guild_id),
+            )
+            results = cursor.fetchall()
+            if results:
+                for result in results:
+                    reactionrole_id = result[0]
+                    cursor.execute(
+                        "DELETE FROM messages WHERE reactionrole_id = ?;",
+                        (reactionrole_id,),
+                    )
+                    cursor.execute(
+                        "DELETE FROM reactionroles WHERE reactionrole_id = ?;",
+                        (reactionrole_id,),
+                    )
+            # Deleting the guilds systemchannels database entries
+            cursor.execute(
+                "DELETE FROM systemchannels WHERE guild_id = ?;",
+                (guild_id,),
+            )
+            conn.commit()
+
+            cursor.close()
+            conn.close()
+
+        except sqlite3.Error as e:
+            return e
+        
     def delete(self, message_id, guild_id=None):
         try:
             conn = sqlite3.connect(self.database)

--- a/core/database.py
+++ b/core/database.py
@@ -139,6 +139,8 @@ class Database:
                 for admin_id in guilds[guild]:
                     cursor.execute("UPDATE admins SET guild_id = ? WHERE role_id = ?;", (guild, admin_id,))
             conn.commit()
+            cursor.execute("DELETE FROM admins WHERE guild_id IS NULL;")
+            conn.commit()
             print("Successfully migrated admins.")
         else:
             print("No admin migration needed.")


### PR DESCRIPTION
Fixes #52 by deleting a guilds database entries after leaving the guild / if the guild gets deleted.
In order to do this I added another database function (remove_guild) which just removes everything directly connected to the guild (message, reactionroles, systemchannels). **Please note**: This will NOT remove the admin role id from the database as admins table does not refer to which guild the admin role belongs to.
