### PR TITLE
add notification toggles and checks

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -488,7 +488,7 @@ async def on_raw_reaction_remove(payload):
             try:
                 await member.remove_roles(role)
                 if db.notify(guild_id):
-                    await user.send(f"You do not have the following role anymore: **{role.name}**")
+                    await member.send(f"You do not have the following role anymore: **{role.name}**")
 
             except discord.Forbidden:
                 await system_notification(

--- a/bot.py
+++ b/bot.py
@@ -158,12 +158,6 @@ async def system_notification(guild_id, text):
             return
 
         if server_channel:
-            server_channel = server_channel[0][0]
-
-        else:
-            await system_notification(None, text)
-
-        if server_channel:
             try:
                 target_channel = await getchannel(server_channel[0][0])
                 await target_channel.send(text)

--- a/bot.py
+++ b/bot.py
@@ -158,6 +158,12 @@ async def system_notification(guild_id, text):
             return
 
         if server_channel:
+            server_channel = server_channel[0][0]
+
+        else:
+            await system_notification(None, text)
+
+        if server_channel:
             try:
                 target_channel = await getchannel(server_channel[0][0])
                 await target_channel.send(text)

--- a/bot.py
+++ b/bot.py
@@ -439,7 +439,7 @@ async def on_raw_reaction_add(payload):
                 try:
                     await member.add_roles(role)
                     if db.notify(guild_id):
-                        await user.send(f"You now have the following role: {role.mention}")
+                        await user.send(f"You now have the following role: **{role.name}**")
 
                 except discord.Forbidden:
                     await system_notification(
@@ -488,7 +488,7 @@ async def on_raw_reaction_remove(payload):
             try:
                 await member.remove_roles(role)
                 if db.notify(guild_id):
-                    await user.send(f"You do not have the following role anymore: {role.mention}")
+                    await user.send(f"You do not have the following role anymore: **{role.name}**")
 
             except discord.Forbidden:
                 await system_notification(

--- a/bot.py
+++ b/bot.py
@@ -158,8 +158,11 @@ async def system_notification(guild_id, text):
             return
 
         if server_channel:
+            server_channel = server_channel[0][0]
+
+        if server_channel:
             try:
-                target_channel = await getchannel(server_channel[0][0])
+                target_channel = await getchannel(server_channel)
                 await target_channel.send(text)
 
             except discord.Forbidden:

--- a/bot.py
+++ b/bot.py
@@ -1072,12 +1072,12 @@ async def toggle_notify(ctx):
     if isadmin(ctx.message.author, ctx.guild.id):
         notify = db.toggle_notify(ctx.guild.id)
         if notify:
-            ctx.send(
+            await ctx.send(
                 "Notifications have been set to ON for this server.\n"
                 "Use this command again to turn them off."
             )
         else:
-            ctx.send(
+            await ctx.send(
                 "Notifications have been set to OFF for this server.\n"
                 "Use this command again to turn them on."
             )

--- a/core/database.py
+++ b/core/database.py
@@ -46,6 +46,12 @@ def initialize(database):
         " INT);"
     )
     cursor.execute(
+        "CREATE TABLE IF NOT EXISTS 'guild_settings' ('guild_id' INT, 'notify' INT);"
+    )
+    cursor.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS guild_id_idx ON guild_settings (guild_id);"
+    )
+    cursor.execute(
         "CREATE UNIQUE INDEX IF NOT EXISTS reactionrole_idx ON messages (reactionrole_id);"
     )
     cursor.execute(
@@ -65,41 +71,6 @@ class Database:
         initialize(self.database)
 
         self.reactionrole_creation = {}
-
-    def migrate_admins(self, client):
-        import discord
-        conn = sqlite3.connect(self.database)
-        cursor = conn.cursor()
-        cursor.execute("PRAGMA table_info(admins);")
-        result = cursor.fetchall()
-        columns = [value[1] for value in result]
-        if "guild_id" not in columns:
-            cursor.execute("SELECT role_id FROM admins")
-            admins = cursor.fetchall()
-            admins2 = []
-            for admin in admins:
-                admins2.append(admin[0])
-            admins = admins2
-            guilds = {}
-            for guild in client.guilds:
-                guilds[guild.id] = []
-                for admin_id in admins:
-                    role = discord.utils.get(guild.roles, id=admin_id)
-                    if role is not None:
-                        guilds[guild.id].append(role.id)
-
-            cursor.execute("ALTER TABLE admins ADD COLUMN 'guild_id' INT;")
-            conn.commit()
-            for guild in guilds:
-                for admin_id in guilds[guild]:
-                    cursor.execute("UPDATE admins SET guild_id = ? WHERE role_id = ?;", (guild, admin_id))
-            conn.commit()
-            cursor.execute("DELETE FROM admins WHERE guild_id IS NULL;")
-            conn.commit()
-            print("Successfully migrated admins.")
-
-        cursor.close()
-        conn.close()
 
     def add_reaction_role(self, rl_dict: dict):
         try:
@@ -502,6 +473,56 @@ class Database:
             cursor.close()
             conn.close()
             return guilds
+
+        except sqlite3.Error as e:
+            return e
+
+    def toggle_notify(self, guild_id: int):
+        # SQLite doesn't support booleans
+        # INTs are used: 1 = True, 0 = False
+        try:
+            conn = sqlite3.connect(self.database)
+            cursor = conn.cursor()
+            cursor.execute("SELECT notify FROM guild_settings WHERE guild_id = ?", (guild_id,))
+            results = cursor.fetchall()
+            if not results:
+                # If the guild was not in the table because the command was never used before
+                notify = 1
+                cursor.execute("INSERT INTO 'guild_settings' ('guild_id', 'notify') values(?,?);", (guild_id, notify))
+            else:
+                notify = results[0][0]
+                if notify:
+                    notify = 0
+                    cursor.execute("UPDATE guild_settings SET notify = ? WHERE guild_id = ?", (notify, guild_id))
+
+                else:
+                    notify = 1
+                    cursor.execute("UPDATE guild_settings SET notify = ? WHERE guild_id = ?", (notify, guild_id))
+            conn.commit()
+            cursor.close()
+            conn.close()
+            return notify
+
+        except sqlite3.Error as e:
+            return e
+
+    def notify(self, guild_id: int):
+        # SQLite doesn't support booleans
+        # INTs are used: 1 = True, 0 = False
+        try:
+            conn = sqlite3.connect(self.database)
+            cursor = conn.cursor()
+            cursor.execute("SELECT notify FROM guild_settings WHERE guild_id = ?", (guild_id,))
+            results = cursor.fetchall()
+            if not results:
+                # If the guild was not in the table because the command was never used before
+                notify = 0
+                cursor.execute("INSERT INTO 'guild_settings' ('guild_id', 'notify') values(?,?);", (guild_id, notify))
+            else:
+                notify = results[0][0]
+            cursor.close()
+            conn.close()
+            return notify
 
         except sqlite3.Error as e:
             return e

--- a/core/database.py
+++ b/core/database.py
@@ -301,10 +301,15 @@ class Database:
         try:
             conn = sqlite3.connect(self.database)
             cursor = conn.cursor()
+            notify = 0
             cursor.execute(
-                "REPLACE INTO 'guild_settings' ('guild_id', 'systemchannel')"
+                "INSERT OR IGNORE INTO guild_settings ('guild_id', 'notify', 'systemchannel')"
                 " values(?, ?);",
-                (guild_id, channel_id),
+                (guild_id, notify, channel_id),
+            )
+            cursor.execute(
+                "UPDATE guild_settings SET systemchannel = ? WHERE guild_id = ?;",
+                (channel_id, guild_id),
             )
             conn.commit()
             cursor.close()
@@ -318,10 +323,15 @@ class Database:
             conn = sqlite3.connect(self.database)
             cursor = conn.cursor()
             channel_id = 0 # Set to false
+            notify = 0
             cursor.execute(
-                "REPLACE INTO guild_settings ('guild_id', 'systemchannel')"
+                "INSERT OR IGNORE INTO guild_settings ('guild_id', 'notify', 'systemchannel')"
                 " values(?, ?);",
-                (guild_id, channel_id),
+                (guild_id, notify, channel_id),
+            )
+            cursor.execute(
+                "UPDATE guild_settings SET systemchannel = ? WHERE guild_id = ?;",
+                (channel_id, guild_id),
             )
             conn.commit()
             cursor.close()
@@ -484,7 +494,8 @@ class Database:
             if not results:
                 # If the guild was not in the table because the command was never used before
                 notify = 1
-                cursor.execute("INSERT INTO 'guild_settings' ('guild_id', 'notify') values(?,?);", (guild_id, notify))
+                systemchannel = 0
+                cursor.execute("INSERT INTO 'guild_settings' ('guild_id', 'notify') values(?, ?, ?);", (guild_id, systemchannel, notify))
             else:
                 notify = results[0][0]
                 if notify:
@@ -513,7 +524,8 @@ class Database:
             if not results:
                 # If the guild was not in the table because the command was never used before
                 notify = 0
-                cursor.execute("INSERT INTO 'guild_settings' ('guild_id', 'notify') values(?,?);", (guild_id, notify))
+                systemchannel = 0
+                cursor.execute("INSERT INTO 'guild_settings' ('guild_id', `systemchannel`, 'notify') values(?, ?, ?);", (guild_id, systemchannel, notify))
             else:
                 notify = results[0][0]
             cursor.close()

--- a/core/schema.py
+++ b/core/schema.py
@@ -107,6 +107,19 @@ class SchemaHandler:
             cursor.execute("DELETE FROM admins WHERE guild_id IS NULL;")
             conn.commit()
 
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='systemchannels';")
+        systemchannels_table = cursor.fetchall()
+        if systemchannels_table:
+            cursor.execute("SELECT * FROM systemchannels;")
+            entries = cursor.fetchall()
+            for entry in entries:
+                guild_id = entry[0]
+                channel_id = entry[1]
+                notify = 0 # Set default to not notify
+                cursor.execute("INSERT INTO guild_settings ('guild_id', 'notify', 'systemchannel') values(?, ?, ?);", (guild_id, notify, channel_id))
+            cursor.execute("DROP TABLE systemchannels;")
+            conn.commit()
+
         cursor.close()
         conn.close()
         self.set_version(2)


### PR DESCRIPTION
**Describe the PR changes**

- Adds a new table called `guild_settings`: I would like to use this for anything guild related in the future, I tried to merge systemchannels into this but I couldn't find an elegant way yet. I will figure it out before merging... Most likely going to copy the contents into a new column and then delete the old table in the `one_to_two` function
- Moved the admin migration introduced by @Edwinexd from core.database to core.schema (I believe everything should still be working correctly)
- Adds a toggle command `rl!notify`
- Guilds are inserted into the table when either `rl!notify` is first used or when the bot checks for it (a user adds or removes a reaction from themselves). In the first case, the bot toggles the notification on, in the latter, the bot sets notifications to off (the "default")

I still need to test this properly, but comments are welcome


Closes #50 
