### PR TITLE
Fix database deleting wrong DB entries

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -299,7 +299,7 @@ async def cleandb():
         except discord.NotFound as e:
             # If unknown channel or unknown message
             if e.code == 10003 or e.code == 10008:
-                delete = db.delete(message[0], message[3])
+                delete = db.delete(message[0])
 
                 if isinstance(delete, Exception):
                     await system_notification(

--- a/core/database.py
+++ b/core/database.py
@@ -258,25 +258,19 @@ class Database:
         except sqlite3.Error as e:
             return e
 
-    def delete(self, message_id, guild_id=None):
+    def delete(self, message_id):
         try:
             conn = sqlite3.connect(self.database)
             cursor = conn.cursor()
-            if guild_id:
-                cursor.execute(
-                    "SELECT reactionrole_id FROM messages WHERE guild_id = ?;",
-                    (guild_id,),
-                )
 
-            else:
-                cursor.execute(
-                    "SELECT reactionrole_id FROM messages WHERE message_id = ?;",
-                    (message_id,),
-                )
+            cursor.execute(
+                "SELECT reactionrole_id FROM messages WHERE message_id = ?;",
+                (message_id,),
+            )
 
-            result = cursor.fetchall()
+            result = cursor.fetcone()
             if result:
-                reactionrole_id = result[0][0]
+                reactionrole_id = result[0]
                 cursor.execute(
                     "DELETE FROM messages WHERE reactionrole_id = ?;",
                     (reactionrole_id,),

--- a/core/database.py
+++ b/core/database.py
@@ -268,7 +268,7 @@ class Database:
                 (message_id,),
             )
 
-            result = cursor.fetcone()
+            result = cursor.fetchone()
             if result:
                 reactionrole_id = result[0]
                 cursor.execute(


### PR DESCRIPTION
**Describe the PR changes**

Stops the bot from nuking the wrong DB entries during cleanup


Mention any issues that this PR would close.
Closes #73 