### PR TITLE
Gracefuller shutdowns/restarts

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -28,7 +28,7 @@ import datetime
 import configparser
 import asyncio
 from shutil import copy
-from sys import platform, exit as shutdown
+from sys import platform
 
 import discord
 from discord.ext import commands, tasks
@@ -1521,7 +1521,7 @@ async def print_version(ctx):
 @bot.command(name="kill")
 async def kill(ctx):
     await ctx.send("Shutting down...")
-    shutdown()  # sys.exit()
+    await bot.close()
 
 
 @commands.is_owner()
@@ -1530,7 +1530,7 @@ async def restart_cmd(ctx):
     if platform != "win32":
         restart()
         await ctx.send("Restarting...")
-        shutdown()  # sys.exit()
+        await bot.close()
 
     else:
         await ctx.send("I cannot do this on Windows.")
@@ -1550,7 +1550,7 @@ async def update(ctx):
         copy(db_file, f"{db_file}.bak")
         restart()
         await ctx.send("Restarting...")
-        shutdown()  # sys.exit()
+        await bot.close()
 
     else:
         await ctx.send("I cannot do this on Windows.")


### PR DESCRIPTION
**Describe the PR changes**

Use of https://discordpy.readthedocs.io/en/latest/api.html#discord.Client.close (`await bot.close()`) to gracefully shut down the bot and close all connections instead of `sys.exit()`