### PR TITLE
Only listen for messages in one channel

### DIFF
--- a/cogs/message.py
+++ b/cogs/message.py
@@ -82,7 +82,7 @@ class Message(commands.Cog):
         cancelled = False
 
         def check(message):
-            return message.author.id == inter.author.id and message.content != ""
+            return message.author.id == inter.author.id and message.content != "" and message.channel.id == inter.channel.id
 
         if not cancelled:
             error_messages = []


### PR DESCRIPTION
**Describe the PR changes**

Changes the RL-New check to only wait for messages in the same channel as the command was executed in (as discussed in the discord server)


Mention any issues that this PR would close.
