### PR TITLE
Use unbuffered python output with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN rm -r /bot/files
 
 WORKDIR /bot
 
-CMD ["python3.9", "bot.py"]
+CMD ["python3.9", "-u", "bot.py"]


### PR DESCRIPTION
This makes the output more useful by removing any buffering. Otherwise messages can be delayed, stuck in the buffer.

```
-u     Force the stdout and stderr streams to be unbuffered.  This option has no effect on the stdin stream.
```