### PR TITLE
Send error when a guild-only command is being ran in DMs

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -36,6 +36,7 @@ class Admin(commands.Cog):
 
     @commands.slash_command(name="admin", description=static_response.get("brief-admin"))
     @commands.has_permissions(administrator=True)
+    @commands.guild_only()
     async def admin(
         self,
         inter,

--- a/cogs/control.py
+++ b/cogs/control.py
@@ -65,6 +65,7 @@ class Control(commands.Cog):
         pass
 
     @controlbot_group.sub_command(name="version", description=static_response.get("brief-version"))
+    @commands.guild_only()
     async def print_version(self, inter):
         await inter.response.defer()
         if not self.bot.isadmin(inter.author, inter.guild.id):

--- a/cogs/errors.py
+++ b/cogs/errors.py
@@ -35,6 +35,8 @@ class Errors(commands.Cog):
     async def on_command_error(self, inter, error):
         if isinstance(error, commands.NotOwner):
             await inter.send(self.bot.response.get("not-owner", guild_id=inter.guild.id))
+        elif isinstance(error, commands.NoPrivateMessage):
+            await inter.send(self.bot.response.get("no-dm"))
         else:
             traceback.print_tb(error.__traceback__)
             print(error)

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -34,6 +34,7 @@ class Help(commands.Cog):
         self.bot = bot
 
     @commands.slash_command(name="help", description=static_response.get("brief-help"))
+    @commands.guild_only()
     async def hlp(self, inter):
         if self.bot.isadmin(inter.author, inter.guild.id):
             await inter.response.defer()

--- a/cogs/message.py
+++ b/cogs/message.py
@@ -70,6 +70,7 @@ class Message(commands.Cog):
         pass
 
     @message_group.sub_command(name="new", description=static_response.get("brief-message-new"))
+    @commands.guild_only()
     async def new(self, inter):
         if not self.bot.isadmin(inter.author, inter.guild.id):
             await inter.send(self.bot.response.get("new-reactionrole-noadmin", guild_id=inter.guild.id))
@@ -388,6 +389,7 @@ class Message(commands.Cog):
             await inter.channel.send(self.bot.response.get("new-reactionrole-cancelled", guild_id=inter.guild.id))
 
     @message_group.sub_command(name="edit", description=static_response.get("brief-message-edit"))
+    @commands.guild_only()
     async def edit_selector(
         self,
         inter: disnake.ApplicationCommandInteraction,
@@ -578,6 +580,7 @@ class Message(commands.Cog):
                 await inter.send(content=self.bot.response.get("edit-permission-error", guild_id=inter.guild.id))
 
     @message_group.sub_command(name="reaction", description=static_response.get("brief-message-reaction"))
+    @commands.guild_only()
     async def edit_reaction(
         self,
         inter,

--- a/i18n/en-gb.json
+++ b/i18n/en-gb.json
@@ -156,5 +156,7 @@
     "settings-activity-option-activity": "The text that appears after 'Playing' in the bot's status message (case sensitive)",
     "activity-add-list-remove": "You need to provide an activity if using `add` or `remove`.",
     "admin-option-action": "Use 'add', 'remove', 'list' to add/remove/view bot admins",
-    "admin-option-role": "The role you want to add/remove as a bot admin"
+    "admin-option-role": "The role you want to add/remove as a bot admin",
+    "no-dm": "This command cannot be used in DMs.",
+    "no-dm-parameters": "This command cannot be used in DMs with the parameter(s) {parameters}."
 }

--- a/tests/language_structure.json
+++ b/tests/language_structure.json
@@ -729,5 +729,15 @@
     "admin-option-role": {
         "max_length": 100,
         "parameters": []
+    },
+    "no-dm": {
+        "max_length": 1024,
+        "parameters": []
+    },
+    "no-dm-parameters": {
+        "max_length": 1024,
+        "parameters": [
+            "parameters"
+        ]
     }
 }


### PR DESCRIPTION
**Describe the PR changes**
Add guild_only checks & error messages for when guild-only commands such as /message new are ran in a non-guild context. 


Mention any issues that this PR would close.
Closes #131 
