### PR TITLE
Disable activities hack

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -50,7 +50,7 @@ class ReactionLight(commands.InteractionBot):
     def __init__(self):
         self.directory = os.path.dirname(os.path.realpath(__file__))
         self.config = parser.Config(self.directory)
-        self.activities = activity.Activities(f"{self.directory}/files/activities.csv")
+        #self.activities = activity.Activities(f"{self.directory}/files/activities.csv")
         self.db = database.Database(f"{self.directory}/files/reactionlight.db")
         self.version = version.get(self.directory)
         self.response = Response(self, f"{self.directory}/i18n", self.config.language)

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -36,12 +36,12 @@ class Settings(commands.Cog):
         # pylint: disable=no-member
         self.maintain_presence.start()
 
-    @tasks.loop(seconds=30)
-    async def maintain_presence(self):
-        await self.bot.wait_until_ready()
-        # Loops through the activities specified in activities.csv
-        current_activity = self.bot.activities.get()
-        await self.bot.change_presence(activity=disnake.Game(name=current_activity))
+    # @tasks.loop(seconds=30)
+    # async def maintain_presence(self):
+    #     await self.bot.wait_until_ready()
+    #     # Loops through the activities specified in activities.csv
+    #     current_activity = self.bot.activities.get()
+    #     await self.bot.change_presence(activity=disnake.Game(name=current_activity))
 
     @commands.slash_command(name="settings")
     async def settings_group(self, inter):

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -34,7 +34,7 @@ class Settings(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         # pylint: disable=no-member
-        self.maintain_presence.start()
+        # self.maintain_presence.start()
 
     # @tasks.loop(seconds=30)
     # async def maintain_presence(self):


### PR DESCRIPTION
This pull request disables the functionality related to maintaining and updating bot activities from `activities.csv`. The most important changes include commenting out the initialization of the `Activities` class in the bot's main file and disabling the `maintain_presence` task loop in the settings cog.

### Changes to activity management:

* [`bot.py`](diffhunk://#diff-36f6200cd8353111badb874140eba3af6055f4cc5839fbdeb9ede992620828c1L53-R53): Commented out the initialization of the `Activities` class (`self.activities`) in the `ReactionLight` bot class. This effectively disables loading activities from `activities.csv`.
* [`cogs/settings.py`](diffhunk://#diff-729509a8fd0c8ff1bf178084e3b0dc15bc877ce3cb3ad5c4a442acdf934a1175L37-R44): Commented out the `maintain_presence` task loop in the `Settings` cog, which was responsible for periodically updating the bot's presence based on activities from `activities.csv`.